### PR TITLE
added keyboard controller for non-AR debugging @KB-101

### DIFF
--- a/src/DebugApp.js
+++ b/src/DebugApp.js
@@ -11,6 +11,8 @@ import { Floor } from './components/Floor';
 import { DebugFloor } from './components/DebugFloor';
 // DebugRenderer
 import { DebugRenderer } from './components/DebugRenderer';
+// Debug Controls
+import { KeyEvents } from './components/KeyEvents';
 // Configs
 import { CONFIGS } from './configs';
 // Dev/Debug
@@ -23,30 +25,53 @@ import './style.css';
 // BEGIN COMPONENT
 export const DebugApp = () => {
   // SCENE SETUP
-  //const scene = new THREE.Scene();
-  //const camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 20);
   const scene = Scene();
   const camera = Camera();
+  camera.setPosition({ x: 0, y: .4, z: .6 });
   const lights = Lights();
   scene.add(lights.getLights());
   // GLTF
   const soldier = Character({...CONFIGS});
   soldier.mesh.visible = true;
   scene.add(soldier.mesh);
+  const animationClock = new THREE.Clock();
   // Geometry
   const floor = new Floor();
   scene.add(floor.mesh);
   const debugFloor = new DebugFloor();
   scene.add(debugFloor.mesh);
-  // RENDERER
+  // Renderer
   const renderer = new DebugRenderer();
-
-  camera.setPosition({ x: 0, y: .4, z: .6 });
-  const clock = new THREE.Clock();
+  // Debug Controls
+  const keyEvents = new KeyEvents();
+  keyEvents.addTimeOutAction({
+    timeoutDuration: 500,
+    timeoutCallback: () => soldier.setClipAction('Idle')
+  })
+  keyEvents.addSubscriber({ 
+    keyName: 'ArrowUp', 
+    keyAction: 'keydown', 
+    callBack: () => { soldier.setDirection(0); soldier.setClipAction('Walk'); }
+    });
+  keyEvents.addSubscriber({ 
+    keyName: 'ArrowRight', 
+    keyAction: 'keydown', 
+    callBack: () => { soldier.setDirection(-Math.PI/2); soldier.setClipAction('Walk'); }
+    });
+  keyEvents.addSubscriber({ 
+    keyName: 'ArrowDown', 
+    keyAction: 'keydown', 
+    callBack: () => { soldier.setDirection(Math.PI); soldier.setClipAction('Walk'); }
+    });
+  keyEvents.addSubscriber({ 
+    keyName: 'ArrowLeft', 
+    keyAction: 'keydown', 
+    callBack: () => { soldier.setDirection(Math.PI/2); soldier.setClipAction('Walk'); }
+    });
   const controls = new OrbitControls( camera.self, renderer.domElement );
 
   function animate() {
-    const dt = clock.getDelta();
+    const dt = animationClock.getDelta();
     soldier.update(dt);
     requestAnimationFrame( animate );
     controls.update();

--- a/src/components/DebugRenderer/index.js
+++ b/src/components/DebugRenderer/index.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 
 export function DebugRenderer () {
   const renderer = new THREE.WebGLRenderer();
-  renderer.setSize( window.innerWidth, window.innerHeight );
+  renderer.setSize( window.innerWidth - 100, window.innerHeight - 100);
   document.body.appendChild( renderer.domElement );
 
   return {

--- a/src/components/KeyEvents/index.js
+++ b/src/components/KeyEvents/index.js
@@ -1,0 +1,47 @@
+// SUBSCRIBE TO KEYBOARD INPUTS
+export function KeyEvents () {
+  this.subscribers = {
+    keydown: {},
+    keyup: {}
+  }
+  this.addSubscriber = this.addSubscriber.bind(this);
+  this.onKeyDown = this.onKeyDown.bind(this);
+  this.onKeyUp = this.onKeyUp.bind(this);
+  this.keyState = {};
+  this.timeoutId;
+  this.timeoutDuration;
+  this.timeoutCallback;
+  document.addEventListener('keydown', this.onKeyDown);
+  document.addEventListener('keyup', this.onKeyUp);
+}
+KeyEvents.prototype.addTimeOutAction = function({
+  timeoutDuration,
+  timeoutCallback
+}) {
+  this.timeoutDuration = timeoutDuration;
+  this.timeoutCallback = timeoutCallback;
+}
+
+KeyEvents.prototype.addSubscriber = function ({
+  keyName,
+  keyAction,
+  callBack
+  }) {
+    if (this.subscribers[keyAction][keyName] === undefined) {
+      this.subscribers[keyAction][keyName] = [callBack];
+    } else {
+      this.subscribers[keyAction][keyName].push(callBack);
+    }
+    this.keyState[keyName] = 'keyup';
+}
+
+KeyEvents.prototype.onKeyDown = function ({ code:keyName }) {
+  if (this.subscribers.keydown[keyName] === undefined) return;
+  this.subscribers.keydown[keyName].forEach(callBack => callBack());
+  clearTimeout(this.timeoutId);
+}
+
+KeyEvents.prototype.onKeyUp = function ({ code:keyName }) {
+  this.timeoutId = setTimeout(() => this.timeoutCallback(), this.timeoutDuration);
+}
+

--- a/src/configs/index.js
+++ b/src/configs/index.js
@@ -1,6 +1,6 @@
 export const CONFIGS = {
   assetPath: '/models/Soldier.glb',
-  walkingSpeed: .028,
+  walkingSpeed: .015,
   meshScaler: .125,
   speedScaler: .25,
   defaultClipAction: 'Idle',

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { App } from './App';
 import { DebugApp } from './DebugApp';
   document.addEventListener("DOMContentLoaded", () => {
-  const app = DebugApp(); //App();
-  window.app = app;
+  //window.app = App(); 
+  window.app = DebugApp(); 
 });


### PR DESCRIPTION
# Description

Added keyboard controller in debug mode. Up/Right/Down/Arrows move character around debug 'floor'.

Example:
```
  const keyEvents = new KeyEvents();
  keyEvents.addTimeOutAction({
    timeoutDuration: 500,
    timeoutCallback: () => soldier.setClipAction('Idle')
  })
  keyEvents.addSubscriber({ 
    keyName: 'ArrowUp', 
    keyAction: 'keydown', 
    callBack: () => { soldier.setDirection(0); soldier.setClipAction('Walk'); }
    });
```

https://github.com/patrick-s-young/ar-kick-ball/assets/42591798/2041dbc3-1272-42a3-b752-75dd73446f40

