### PR TITLE
reticle emulation in debug mode @KB-107

### DIFF
--- a/src/cannon/bodies/BallBody/index.js
+++ b/src/cannon/bodies/BallBody/index.js
@@ -2,10 +2,8 @@ import * as CANNON from 'cannon-es';
 import { COLLISION_GROUPS, COLLISION_FILTER_MASKS } from '@cannon/collisions';
 import { ballMaterial } from '@cannon/materials';
 
-export const BallBody = ({
-  world
-}) => {
-  const startPosition = [.2, .2, 0];
+export const BallBody = ({ world }) => {
+  const startPosition = [0, 0.2, 0];
   const radius = .05;
   const body = new CANNON.Body({ 
     mass: .5, 
@@ -16,9 +14,19 @@ export const BallBody = ({
     collisionFilterMask: COLLISION_FILTER_MASKS.BALL
   });
 
-  world.addBody(body);
+  const addToWorld = () => {
+    world.addBody(body);
+  }
+
+  const setPosition = (positionArr) => {
+    console.log('positionArr:', positionArr)
+    body.position.set(...positionArr)
+  }
 
   return {
-    get body() { return body }
+    get body() { return body },
+    addToWorld,
+    setPosition,
+    get position() { return body.position }
   }
 }

--- a/src/cannon/bodies/CharacterBody/index.js
+++ b/src/cannon/bodies/CharacterBody/index.js
@@ -25,6 +25,7 @@ export const CharacterBody = ({
 
   world.addBody(body);
 
+
   return {
     get body() { return body }
   }

--- a/src/cannon/bodies/FloorBody/index.js
+++ b/src/cannon/bodies/FloorBody/index.js
@@ -22,9 +22,12 @@ export const FloorBody = ({
     quaternion
   });
 
-  world.addBody(boxBody);
+  const addToWorld = () => {
+    world.addBody(boxBody);
+  }
 
   return {
-    get body() { return boxBody }
+    get body() { return boxBody },
+    addToWorld
   }
 }

--- a/src/meshes/Ball/index.js
+++ b/src/meshes/Ball/index.js
@@ -7,7 +7,7 @@ export function Ball() {
   const geometry = new THREE.SphereGeometry(.05, 16, 8);
   const mesh = new THREE.Mesh( geometry, materialBasic );
   mesh.position.set(0, 0, 0);
-  mesh.visible = true;
+  mesh.visible = false;
   let body;
 
   const setBody = (_body) => {
@@ -21,6 +21,8 @@ export function Ball() {
 
   return {
     get mesh() { return mesh },
+    set visible(isVisible) { mesh.visible = isVisible },
+    get visible() { return mesh.visible },
     setBody,
     setPosition: (newPosition) => { mesh.position.set(...newPosition) },
     update

--- a/src/meshes/Reticle/index.js
+++ b/src/meshes/Reticle/index.js
@@ -23,17 +23,24 @@ export function Reticle() {
     mesh.matrix.fromArray(matrixArray);
   }
 
+  const setPosition = (positionVec3) => {
+    mesh.matrix.setPosition(positionVec3);
+  }
+
   const updateMixer = (deltaSeconds) => {
     if (mesh.visible) anim.mixer?.update(deltaSeconds);
   }
 
   return {
     getMesh: () => { return mesh },
+    get mesh() { return mesh },
     set visible(isVisible) { mesh.visible = isVisible },
     get visible() { return mesh.visible },
     get matrix() { return mesh.matrix },
     get anim() { return anim },
+    get position() { return mesh.position },
     updateMixer,
-    setMatrixFromArray
+    setMatrixFromArray,
+    setPosition
   }
 }

--- a/src/three/Character/index.js
+++ b/src/three/Character/index.js
@@ -80,6 +80,13 @@ export function Character({
     body = _body;
   }
 
+  const setPosition = ({x, y, z}) => {
+    mesh.position.x = x;
+    mesh.position.z = z;
+    body.position.x = x;
+    body.position.z = z;
+  }
+
   return {
     get mesh() { return mesh },
     get position() { return mesh.position},
@@ -93,6 +100,7 @@ export function Character({
     setDirection: (radians) =>  rotation.setDirection(radians),
     setVisible,
     getBoundingBox,
-    setBody
+    setBody,
+    setPosition
   }
 }


### PR DESCRIPTION
# Description

Reticle emulation added to debug mode. By mirroring as much of the AR mode as possible, 'debug mode' is made more effective when designing new methods and patterns.



https://github.com/patrick-s-young/ar-kick-ball/assets/42591798/7af9d692-98da-4129-8a50-611520651758

