### PR TITLE
KB-113 bone and body animation refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -131,11 +131,18 @@ export const App = () => {
       meshes.floorShadow.setPosition({ x, y, z});
       meshes.floorShadow.visible = true;
       // soldier
-     // cannon.characterBody = CharacterBody({ world });
       cannon.rightFootBody = FootBody({ world });
       cannon.leftFootBody = FootBody({ world });
-    //  meshes.soldier.setBody(cannon.characterBody);
-      meshes.soldier.setFeetBodies({ rightFoot: cannon.rightFootBody, leftFoot: cannon.leftFootBody });
+      meshes.soldier.addBoneBodyAnimation({
+        boneName: 'mixamorigRightFoot',
+        body: cannon.rightFootBody.body,
+        bodyOffset: [-0.002, 0.01, 0.003]
+      });
+      meshes.soldier.addBoneBodyAnimation({
+        boneName: 'mixamorigLeftFoot',
+        body: cannon.leftFootBody.body,
+        bodyOffset: [0.002, 0.01, 0.003]
+      });
       meshes.soldier.setPosition({ x, y, z})
       meshes.soldier.setVisible(true);
       meshAnimationUpdate.push({ name: 'soldier', update: (dt) => meshes.soldier.update(dt) });

--- a/src/DebugApp.js
+++ b/src/DebugApp.js
@@ -89,10 +89,10 @@ export const DebugApp = () => {
     three.renderer.domElement.addEventListener('pointermove', onPointerMove);
     three.renderer.domElement.addEventListener('click', onClick);
 
-    console.log('rightFootBone:', meshes.soldier.rightFootBone);
-    const boneWorldPos = new THREE.Vector3()
-    meshes.soldier.rightFootBone.getWorldPosition(boneWorldPos);
-    console.log('rightFootBone worldPosition:', boneWorldPos)
+    //console.log('rightFootBone:', meshes.soldier.rightFootBone);
+   // const boneWorldPos = new THREE.Vector3()
+  //  meshes.soldier.rightFootBone.getWorldPosition(boneWorldPos);
+   // console.log('rightFootBone worldPosition:', boneWorldPos)
 
   }
 
@@ -132,11 +132,18 @@ export const DebugApp = () => {
     // floor emulation
     meshes.debugFloor.setPosition({ x, y: y - 0.01, z});
     // soldier
-    //cannon.characterBody = CharacterBody({ world });
     cannon.rightFootBody = FootBody({ world });
     cannon.leftFootBody = FootBody({ world });
-   // meshes.soldier.setBody(cannon.characterBody);
-    meshes.soldier.setFeetBodies({ rightFoot: cannon.rightFootBody, leftFoot: cannon.leftFootBody });
+    meshes.soldier.addBoneBodyAnimation({
+      boneName: 'mixamorigRightFoot',
+      body: cannon.rightFootBody.body,
+      bodyOffset: [-0.002, 0.01, 0.003]
+    });
+    meshes.soldier.addBoneBodyAnimation({
+      boneName: 'mixamorigLeftFoot',
+      body: cannon.leftFootBody.body,
+      bodyOffset: [0.002, 0.01, 0.003]
+    });
     meshes.soldier.setPosition({ x, y, z})
     meshes.soldier.setVisible(true);
     meshAnimationUpdate.push({ name: 'soldier', update: (dt) => meshes.soldier.update(dt) });


### PR DESCRIPTION
# Description

Refactor method for adding and animation cannon bodies to bone position/rotation.

To assign a cannon body to a mesh bone:

```
  meshes.soldier.addBoneBodyAnimation({
    boneName: 'mixamorigRightFoot',
    body: cannon.rightFootBody.body,
    bodyOffset: [-0.002, 0.01, 0.003]
  });
```

In the Character animation update:

```
  const boneWorldPos = new THREE.Vector3();
  const boneWorldQuaternion = new THREE.Quaternion();
  boneBodyAnimations.forEach(item => {
    item.bone.getWorldPosition(boneWorldPos);
    item.bone.getWorldQuaternion(boneWorldQuaternion);
    const _bodyOffset = new THREE.Vector3(...item.bodyOffset);
    _bodyOffset.applyQuaternion(boneWorldQuaternion);
    boneWorldPos.add(_bodyOffset);
    item.body.position.set(...boneWorldPos);
    item.body.quaternion.copy(boneWorldQuaternion);
  });
```